### PR TITLE
Added new method: `justWork`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,13 @@
 export function isActually (isNotActually){
     return !Boolean( isNotActually == undefined || isNotActually == '' || isNotActually == null );
 }
+
+export function justWork (...likeMagic) {
+    let nowGood, actually;
+    if (!likeMagic.length) return;
+    likeMagic.forEach(thing => {
+        nowGood = typeof thing === 'function' ? thing : nowGood;
+        actually = Number.isFinite(thing) ? thing : actually > 0 ? actually : 0;
+    });
+    return setTimeout(nowGood, actually);
+}


### PR DESCRIPTION
@PrestonR @alexhgian @niklassletteland 

> `setTimeout` is awesome, but `justWork` is amazing.

Better than `setTimeout`, it comes default with 'set timeout zero' :)

`actually.justWork(likeMagic)` - Omit delay value for default 0ms delay
`actually.justWork(likeMagic, 2000)` - Add delay value to delay 
`actually.justWork(likeMagic, XMLHttpRequest)` - non-finite numbers will return immediately
`actually.justWork(1000, likeMagic, 2000)` - Will run `likeMagic` fn after 2000ms
`actually.justWork(() => console.log('foo'), 3000, '2000', () => console.log('bar'))` - Will run last, valid fn found in 3000ms
etc.

---

For a demo of it working with import/export, please see https://glitch.com/~actually-justwork<br>
It should give you instructions on how to view the demo.

If you just want to see the method running with a bunch of argument examples, please see http://jsbin.com/kevoromigo/edit?js,console,output

Cheers.
  
  
  